### PR TITLE
Basecookie

### DIFF
--- a/livetest/__init__.py
+++ b/livetest/__init__.py
@@ -37,7 +37,7 @@ import sys
 import webtest
 import httplib
 import urlparse
-from webtest import BaseCookie, CookieError
+from Cookie import BaseCookie, CookieError
 
 conn_classes = {'http': httplib.HTTPConnection,
                 'https': httplib.HTTPSConnection}


### PR DESCRIPTION
Fixes Issue #2 by importing BaseCookie directly from Cookie instead of through webtest.
