### PR TITLE
Setup problem

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,8 @@ except ImportError:
     from setuptools import setup, find_packages
 
 
-import livetest
-
 setup(name='livetest',
-      version=livetest.__version__,
+      version='0.5',
       description='Test against a live site with an API like Paste WebTest',
       long_description=file('README.rst').read(),
       classifiers=[
@@ -23,7 +21,7 @@ setup(name='livetest',
       ],
       keywords='http integration wsgi test unit tests testing web functional',
       author='Scott Torborg',
-      author_email=livetest.__author__,
+      author_email='storborg@mit.edu',
       url='http://github.com/storborg/livetest',
       license='MIT',
       packages=find_packages(exclude=['ez_setup', 'tests']),


### PR DESCRIPTION
The change in ea6cfefd04432612344eedf2917a9a2076366fa1 to import livetest so you have access to **author** and **version** breaks installation. If you don't have webtest installed, an ImportError is thrown because **init**.py imports it before the setup has had a chance to install it. This branch reverts that change and duplicates the author and version information in setup.py.
